### PR TITLE
chore: bump probe version from 3.18.1 to 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.18 as builder
 LABEL org.opencontainers.image.source=https://github.com/altertek/docker-ooni-probe
 LABEL org.opencontainers.image.authors=Altertek
 
-ARG PROBEVERSION=v3.18.1
+ARG PROBEVERSION=v3.19.0
 ARG TARGETPLATFORM
 ENV TARGETPLATFORM=${TARGETPLATFORM:-"linux/amd64"}
 


### PR DESCRIPTION
https://github.com/ooni/probe-cli/releases/tag/v3.19.0