### PR TITLE
chore: bump probe version to 3.21.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.19 as builder
 LABEL org.opencontainers.image.source=https://github.com/altertek/docker-ooni-probe
 LABEL org.opencontainers.image.authors=Altertek
 
-ARG PROBEVERSION=v3.20.1
+ARG PROBEVERSION=v3.21.1
 ARG TARGETPLATFORM
 ENV TARGETPLATFORM=${TARGETPLATFORM:-"linux/amd64"}
 


### PR DESCRIPTION
https://github.com/ooni/probe-cli/releases/tag/v3.21.1